### PR TITLE
Change GitHub.com footer link to HTTPS

### DIFF
--- a/src/Hpaste/View/Layout.hs
+++ b/src/Hpaste/View/Layout.hs
@@ -70,7 +70,7 @@ nav = do
 -- | Page footer.
 foot :: Markup
 foot = H.div ! aClass "footer" $ p $
-  lnk "http://github.com/chrisdone/lpaste" "Web site source code on Github"
+  lnk "https://github.com/chrisdone/lpaste" "Web site source code on Github"
   //
   lnk "http://book.realworldhaskell.org/" "Real World Haskell"
   //


### PR DESCRIPTION
This commit changes the hyperlink to the “Web site source code on
Github” (http://github.com/chrisdone/lpaste) in the page footer to use
HTTPS rather than plain HTTP.
