### PR TITLE
Change Haskell.org footer link to HTTPS

### DIFF
--- a/src/Hpaste/View/Layout.hs
+++ b/src/Hpaste/View/Layout.hs
@@ -74,7 +74,7 @@ foot = H.div ! aClass "footer" $ p $
   //
   lnk "http://book.realworldhaskell.org/" "Real World Haskell"
   //
-  lnk "http://haskell.org/" "Haskell.org"
+  lnk "https://haskell.org/" "Haskell.org"
   //
   lnk "http://planet.haskell.org/" "Planet Haskell"
 


### PR DESCRIPTION
This commit changes the hyperlink to Haskell.org in the page footer to
use HTTPS rather than plain HTTP.
